### PR TITLE
Add regression and engine performance test suite

### DIFF
--- a/ChessMultitool.Tests/ChessMultitool.Tests.csproj
+++ b/ChessMultitool.Tests/ChessMultitool.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ChessMultitool\Logic\**\*.cs" Exclude="..\ChessMultitool\Logic\Images.cs" LinkBase="Logic" />
+  </ItemGroup>
+</Project>

--- a/ChessMultitool.Tests/EngineRegressionTests.cs
+++ b/ChessMultitool.Tests/EngineRegressionTests.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using ChessLogic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ChessMultitool.Tests;
+
+public sealed class EngineRegressionTests
+{
+    private readonly ITestOutputHelper output;
+
+    public EngineRegressionTests(ITestOutputHelper output)
+    {
+        this.output = output;
+    }
+
+    [Theory]
+    [InlineData(1, 20)]
+    [InlineData(2, 400)]
+    [InlineData(3, 8902)]
+    public void Perft_InitialPosition_MatchesReferenceCounts(int depth, long expectedNodes)
+    {
+        var state = new GameState(Player.White, Board.Initial());
+
+        var nodes = Perft(state, depth);
+
+        Assert.Equal(expectedNodes, nodes);
+    }
+
+    [Fact]
+    public void MakeUnmakeFast_RestoresBoardStateAfterSearchTreeTraversal()
+    {
+        var state = new GameState(Player.White, Board.Initial());
+        var snapshot = new StateString(state.CurrentPlayer, state.Board).ToString();
+
+        _ = Perft(state, 3);
+
+        var afterTraversal = new StateString(state.CurrentPlayer, state.Board).ToString();
+        Assert.Equal(snapshot, afterTraversal);
+    }
+
+    [Fact]
+    public void EnginePerformance_ReportsUsefulMetrics()
+    {
+        var engine = new MiniMaxEngine();
+        var state = Fen.FromFen("r1bqkbnr/pppp1ppp/2n5/4p3/3P4/5N2/PPP1PPPP/RNBQKB1R b KQkq - 1 3");
+
+        long generatedMoves = 0;
+        long visitedNodes = 0;
+        long leafEvaluations = 0;
+
+        var stopwatch = Stopwatch.StartNew();
+        var bestMove = engine.FindBestMove(
+            state,
+            depth: 4,
+            timeMs: 1500,
+            onStats: (generated, visited, leafs) =>
+            {
+                generatedMoves = generated;
+                visitedNodes = visited;
+                leafEvaluations = leafs;
+            });
+        stopwatch.Stop();
+
+        var elapsedSeconds = Math.Max(stopwatch.Elapsed.TotalSeconds, 1e-6);
+        var nodesPerSecond = visitedNodes / elapsedSeconds;
+        var leavesPerSecond = leafEvaluations / elapsedSeconds;
+        var averageCostPerNodeNs = visitedNodes > 0
+            ? stopwatch.Elapsed.TotalMilliseconds * 1_000_000d / visitedNodes
+            : double.PositiveInfinity;
+
+        output.WriteLine($"Elapsed: {stopwatch.ElapsedMilliseconds} ms");
+        output.WriteLine($"BestMove: {bestMove}");
+        output.WriteLine($"VisitedNodes: {visitedNodes}");
+        output.WriteLine($"GeneratedMoves: {generatedMoves}");
+        output.WriteLine($"LeafEvaluations: {leafEvaluations}");
+        output.WriteLine($"Nodes/s: {nodesPerSecond:N0}");
+        output.WriteLine($"Leaves/s: {leavesPerSecond:N0}");
+        output.WriteLine($"Average cost per node (ns): {averageCostPerNodeNs:N0}");
+
+        Assert.NotNull(bestMove);
+        Assert.True(visitedNodes > 0, "Le moteur doit visiter au moins un nœud.");
+        Assert.True(leafEvaluations > 0, "Le moteur doit évaluer au moins une feuille.");
+        Assert.True(nodesPerSecond > 100, "Le débit en nodes/s est anormalement bas.");
+        Assert.True(averageCostPerNodeNs > 0, "Le coût moyen par nœud doit être positif.");
+    }
+
+    private static long Perft(GameState state, int depth)
+    {
+        if (depth == 0)
+        {
+            return 1;
+        }
+
+        var moves = state.AllLegalMovesFor(state.CurrentPlayer).ToList();
+        if (depth == 1)
+        {
+            return moves.Count;
+        }
+
+        long nodes = 0;
+        foreach (var move in moves)
+        {
+            state.MakeMoveFast(move, out var undo);
+            try
+            {
+                nodes += Perft(state, depth - 1);
+            }
+            finally
+            {
+                state.UnmakeMoveFast(undo);
+            }
+        }
+
+        return nodes;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # ChessMultitool
+
+## Tests automatisés
+
+Le dossier `ChessMultitool.Tests` contient des tests orientés moteur d'échecs pour limiter les régressions :
+
+- `Perft_InitialPosition_MatchesReferenceCounts` vérifie les comptes de nœuds de référence (profondeurs 1 à 3).
+- `MakeUnmakeFast_RestoresBoardStateAfterSearchTreeTraversal` vérifie que la recherche restaure bien l'état du plateau.
+- `EnginePerformance_ReportsUsefulMetrics` exécute une recherche minimax et publie des métriques :
+  - `nodes/s`
+  - coût moyen par nœud (ns)
+  - feuilles/s
+
+### Exécution
+
+```bash
+dotnet test ChessMultitool.Tests/ChessMultitool.Tests.csproj -c Release --logger "console;verbosity=detailed"
+```
+
+Le test de performance est conçu pour rester stable en CI (assertions minimales), tout en affichant des métriques exploitables pour suivre l'évolution du moteur.


### PR DESCRIPTION
### Motivation

- Add automated tests to prevent regressions in the chess engine and to track performance metrics (nodes/s, leaves/s, average cost per node). 
- Provide a lightweight, CI-friendly test set that validates move generation, undo correctness and gives reproducible instrumentation for engine evolution.

### Description

- Add a new xUnit test project `ChessMultitool.Tests` targeting `net9.0` and configured with `Microsoft.NET.Test.Sdk`, `xunit` and `coverlet.collector`.
- Include the engine logic sources in the test project with `Compile` of `..\ChessMultitool\Logic\**\*.cs` while excluding the MAUI-specific `Images.cs` file.
- Add `EngineRegressionTests` with a `Perft_InitialPosition_MatchesReferenceCounts` theory checking perft node counts for depths 1..3 (`20`, `400`, `8902`).
- Add `MakeUnmakeFast_RestoresBoardStateAfterSearchTreeTraversal` to assert `MakeMoveFast`/`UnmakeMoveFast` restore the state, and `EnginePerformance_ReportsUsefulMetrics` which runs `MiniMaxEngine.FindBestMove` and reports `nodes/s`, `leaves/s` and average cost per node.
- Update `README.md` with instructions to run the tests via `dotnet test ChessMultitool.Tests/ChessMultitool.Tests.csproj -c Release --logger "console;verbosity=detailed"`.

### Testing

- New automated tests added: `Perft_InitialPosition_MatchesReferenceCounts`, `MakeUnmakeFast_RestoresBoardStateAfterSearchTreeTraversal`, and `EnginePerformance_ReportsUsefulMetrics` (all in `ChessMultitool.Tests/EngineRegressionTests.cs`).
- An attempt to wire and run the tests in this environment failed because the `.NET` SDK is not available, so `dotnet` commands (`dotnet sln` / `dotnet test`) could not be executed here.
- The tests are runnable locally or in CI with the documented command `dotnet test ChessMultitool.Tests/ChessMultitool.Tests.csproj -c Release --logger "console;verbosity=detailed"` and include conservative assertions so they remain stable across environments while emitting useful performance metrics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d68c09b0a48325b2c9a358b01d695d)