### PR TITLE
Add coverlet runsettings and enable cobertura+opencover coverage collection in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,8 @@ jobs:
           dotnet test .\ChessMultitool.Tests\ChessMultitool.Tests.csproj `
             -c Release `
             --no-build `
-            --collect:"XPlat Code Coverage;Format=opencover" `
+            --collect:"XPlat Code Coverage" `
+            --settings .\ChessMultitool.Tests\coverlet.runsettings `
             --results-directory .\ChessMultitool.Tests\TestResults
 
       - name: Sonar end

--- a/ChessMultitool.Tests/ChessMultitool.Tests.csproj
+++ b/ChessMultitool.Tests/ChessMultitool.Tests.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <RunSettingsFilePath>coverlet.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ChessMultitool.Tests/coverlet.runsettings
+++ b/ChessMultitool.Tests/coverlet.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura,opencover</Format>
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Le dossier `ChessMultitool.Tests` contient des tests orientés moteur d'échecs 
 
 ```bash
 dotnet test ChessMultitool.Tests/ChessMultitool.Tests.csproj -c Release --logger "console;verbosity=detailed"
+
+# Génère aussi le coverage (cobertura + opencover) avec include de l'assembly de tests
+dotnet test ChessMultitool.Tests/ChessMultitool.Tests.csproj -c Release --collect:"XPlat Code Coverage" --settings ChessMultitool.Tests/coverlet.runsettings
 ```
 
 Le test de performance est conçu pour rester stable en CI (assertions minimales), tout en affichant des métriques exploitables pour suivre l'évolution du moteur.


### PR DESCRIPTION
### Motivation
- Produce consistent coverage output (Cobertura and OpenCover) and include the test assembly in coverage reports, and make CI use a stable runsettings file.

### Description
- Add `ChessMultitool.Tests/coverlet.runsettings` configuring the `XPlat Code Coverage` collector to emit `cobertura,opencover` and include the test assembly.
- Set `<RunSettingsFilePath>coverlet.runsettings</RunSettingsFilePath>` in `ChessMultitool.Tests/ChessMultitool.Tests.csproj` so the project knows the runsettings file.
- Update `.github/workflows/build.yml` to use `--collect:"XPlat Code Coverage"` and pass `--settings .\ChessMultitool.Tests\coverlet.runsettings` to `dotnet test` instead of embedding the format in the `--collect` argument.
- Document the new test/coverage command in `README.md` showing how to run tests with coverage output in both formats.

### Testing
- Ran `dotnet test ChessMultitool.Tests/ChessMultitool.Tests.csproj -c Release --collect:"XPlat Code Coverage" --settings ChessMultitool.Tests/coverlet.runsettings` and the test run completed successfully.
- CI will run the updated workflow which invokes the same `dotnet test` invocation to generate `cobertura` and `opencover` reports for SonarCloud and other tools.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f89cba588325981101c7b0625636)