### PR TITLE
Generate OpenCover report with coverlet.msbuild for SonarCloud and update CI/README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,10 @@ jobs:
           dotnet test .\ChessMultitool.Tests\ChessMultitool.Tests.csproj `
             -c Release `
             --no-build `
-            --collect:"XPlat Code Coverage;Format=opencover" `
+            /p:CollectCoverage=true `
+            /p:CoverletOutputFormat=opencover `
+            /p:IncludeTestAssembly=true `
+            /p:CoverletOutput=.\ChessMultitool.Tests\TestResults\coverage.opencover.xml `
             --results-directory .\ChessMultitool.Tests\TestResults
 
       - name: Sonar end

--- a/ChessMultitool.Tests/ChessMultitool.Tests.csproj
+++ b/ChessMultitool.Tests/ChessMultitool.Tests.csproj
@@ -13,8 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Le dossier `ChessMultitool.Tests` contient des tests orientés moteur d'échecs 
 
 ```bash
 dotnet test ChessMultitool.Tests/ChessMultitool.Tests.csproj -c Release --logger "console;verbosity=detailed"
+
+# Génère le coverage OpenCover (compatible SonarCloud)
+dotnet test ChessMultitool.Tests/ChessMultitool.Tests.csproj -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:IncludeTestAssembly=true /p:CoverletOutput=ChessMultitool.Tests/TestResults/coverage.opencover.xml
 ```
 
 Le test de performance est conçu pour rester stable en CI (assertions minimales), tout en affichant des métriques exploitables pour suivre l'évolution du moteur.


### PR DESCRIPTION
### Motivation

- Ensure the CI pipeline produces an OpenCover-compatible coverage report for SonarCloud instead of relying on the `XPlat` collector invocation. 
- Move to the MSBuild-based Coverlet integration to control output path and format from the `dotnet test` command. 

### Description

- Updated `.github/workflows/build.yml` to replace the `--collect:"XPlat Code Coverage;Format=opencover"` test flag with MSBuild coverlet properties: `/p:CollectCoverage=true`, `/p:CoverletOutputFormat=opencover`, `/p:IncludeTestAssembly=true`, and `/p:CoverletOutput=.\ChessMultitool.Tests\TestResults\coverage.opencover.xml`.
- Swapped the test project package from `coverlet.collector` to `coverlet.msbuild` in `ChessMultitool.Tests/ChessMultitool.Tests.csproj`.
- Updated `README.md` with a sample `dotnet test` command that produces an OpenCover report suitable for SonarCloud ingestion.

### Testing

- Ran the CI sequence that executes `dotnet build` and `dotnet test` with the new MSBuild coverlet properties, producing `ChessMultitool.Tests/TestResults/coverage.opencover.xml`, and the steps completed successfully.
- The Sonar scanner begin/end steps were exercised in the workflow and completed without errors in the CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f89cba588325981101c7b0625636)